### PR TITLE
re-order outline

### DIFF
--- a/customization/README.md
+++ b/customization/README.md
@@ -3,7 +3,7 @@
 * [Configuring ArchivesSpace](./configuration.md)
 * [Adding support for additional username/password-based authentication backends](./authentication.md)
 * [Configuring LDAP authentication](./ldap.md)
-* [ArchivesSpace Plug-ins](./plugins.md)
 * [Customizing text in ArchivesSpace](./locales.md)
+* [ArchivesSpace Plug-ins](./plugins.md)
 * [Theming ArchivesSpace](./theming.md)
 * [Managing frontend assets with Bower](./bower.md)


### PR DESCRIPTION
I believe the outline should be re-ordered with "ease of use" for a new user in mind.

Even though customizing text involves the plugins/local/ subdirectory, understanding plugins in general is *not* necessary to accomplish this goal.