### PR TITLE
Update yard gem because of CVE-2017-17042 lib/yard/core_ext/file.rb 

### DIFF
--- a/_yard/Gemfile
+++ b/_yard/Gemfile
@@ -2,6 +2,6 @@
 source "https://rubygems.org"
 
 group :doc do
-  gem "yard"
+  gem "yard", "~> 0.9.11"
   gem "kramdown"
 end

--- a/_yard/Gemfile.lock
+++ b/_yard/Gemfile.lock
@@ -1,15 +1,15 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    kramdown (1.13.2)
-    yard (0.9.8)
+    kramdown (1.16.2)
+    yard (0.9.12)
 
 PLATFORMS
-  java
+  ruby
 
 DEPENDENCIES
   kramdown
-  yard
+  yard (~> 0.9.11)
 
 BUNDLED WITH
-   1.12.5
+   1.16.1


### PR DESCRIPTION
in the server in YARD before 0.9.11 does not block relative paths with an initial ../ sequence, which allows attackers to conduct directory traversal attacks and read arbitrary files.