### PR TITLE
add instructions for adding custom reports to plugins

### DIFF
--- a/customization/plugins.md
+++ b/customization/plugins.md
@@ -209,6 +209,12 @@ Valid values are `:text:`, `:boolean`, `:date` and `:enum`.  Finally,
 the `:solr_field` parameter controls which field is used from the
 underlying index.
 
+## Adding Custom Reports
+
+Custom reports may be added to plug-ins by adding a new report model as a subclass of `AbstractReport` to `plugins/[plugin-name]/backend/model/`. Look to existing reports in reports subdirectory of the ArchivesSpace base directory for examples of how to structure a report model. 
+
+There are several limitations to adding reports to plug-ins, including that reports from plug-ins may only use the generic report template. ArchivesSpace only searches for report templates in the reports subdirectory of the ArchivesSpace base directory, not in plug-in directories. If you would like to implement a custom report with a custom template, consider adding the report to `archivesspace/reports/` instead of `archivesspace/plugins/[plugin-name]/backend/model/`.
+
 
 ## Further information
 


### PR DESCRIPTION
Added basic instructions for adding customs reports to plug-ins, along with caveats about the limitations of adding reports to plugins rather than in the archivesspace/reports directory as discussed in https://github.com/archivesspace/tech-docs/issues/17