### PR TITLE
Fix special chars

### DIFF
--- a/administration/upgrading/UPGRADING_1.5.0.md
+++ b/administration/upgrading/UPGRADING_1.5.0.md
@@ -1,30 +1,30 @@
-UPGRADING TO 1.5.0 
+UPGRADING TO 1.5.0
 ===============================================================================================
 
 Additional upgrade considerations specific to this release, which also apply to upgrading from 1.4.2 or lower to any version through 2.0.1. Refer to the [upgrade documentation](http://archivesspace.github.io/archivesspace/user/upgrading-to-a-new-release-of-archivesspace/) for the standard instructions that apply in all cases.
 
 # General overview
 
-The upgrade process to the new data model in 1.5.0 requires considerable data transformation and it is important for users to review this document to understand the implications and possible side-effects. 
+The upgrade process to the new data model in 1.5.0 requires considerable data transformation and it is important for users to review this document to understand the implications and possible side-effects.
 
 A quick overview of the steps are:
 
 1. Review this document and understand how the upgrade will impact your data, paying particular attention to the [Preparation section](#preparation) .
 2. [Backup your database](http://archivesspace.github.io/archivesspace/user/backup-and-recovery/).
 3. No, really, [backup your database](http://archivesspace.github.io/archivesspace/user/backup-and-recovery/).
-4. It is suggested that [users start with a new solr index](http://archivesspace.github.io/archivesspace/user/re-creating-indexes/). To do this, delete the data/solr_index/index directory and all files in the data/indexer_state directory. The embedded version of Solr has been upgraded, which should result in a much more compact index size. 
+4. It is suggested that [users start with a new solr index](http://archivesspace.github.io/archivesspace/user/re-creating-indexes/). To do this, delete the data/solr_index/index directory and all files in the data/indexer_state directory. The embedded version of Solr has been upgraded, which should result in a much more compact index size.
 5. Follow the standard [upgrading instructions](http://archivesspace.github.io/archivesspace/user/upgrading-to-a-new-release-of-archivesspace/). Important to note:  The setup-database.sh|bat script will modify your database schema, but it will not move the data. If you are currently using the container management plugin you will need to remove it from the list of plugins in your config file prior to starting ArchivesSpace.
-6. Start ArchivesSpace. When 1.5.0 starts for the first time, a conversion process will kick off and move the data into the new table structure. **During this time, the application will be unavailable until it completes**. Duration depends on the size of your data and server resources, with a few minutes for very small databases to several hours for very large ones. 
-7. When the conversion is done, the web application will start and the indexer will rebuild your index. Performance might be slower while the indexer runs, depending on your server environment and available resources. 
+6. Start ArchivesSpace. When 1.5.0 starts for the first time, a conversion process will kick off and move the data into the new table structure. **During this time, the application will be unavailable until it completes**. Duration depends on the size of your data and server resources, with a few minutes for very small databases to several hours for very large ones.
+7. When the conversion is done, the web application will start and the indexer will rebuild your index. Performance might be slower while the indexer runs, depending on your server environment and available resources.
 8. Review the [output of the conversion process](#conversion) following the instructions below. How long it takes for the report to load will depend on the number of entries included in it.
 
-# Preparing for and Converting to the New Container Management Functionality
+## Preparing for and Converting to the New Container Management Functionality
 
 With version 1.5.0, ArchivesSpace is adopting a new data model that will enable more capable and efficient management of the containers in which you store your archival materials.  To take advantage of this improved functionality:
 * Repositories already using ArchivesSpace as a production application will need to upgrade their ArchivesSpace applications to the version 1.5.0.  (This upgrade / conversion must be done to take advantage of any other new features / bug fixes in ArchivesSpace 1.5.0 or later versions.)
-* Repositories not yet using ArchivesSpace in production but needing to migrate data from the Archivists’ Toolkit or Archon will need to migrate their data to version 1.4.2 of ArchivesSpace or earlier and then upgrade that version to version 1.5.0.  (This can be done when your repository is ready to migrate to ArchivesSpace.) 
+* Repositories not yet using ArchivesSpace in production but needing to migrate data from the Archivists’ Toolkit or Archon will need to migrate their data to version 1.4.2 of ArchivesSpace or earlier and then upgrade that version to version 1.5.0.  (This can be done when your repository is ready to migrate to ArchivesSpace.)
 * Repositories not yet using ArchivesSpace in production and not needing to migrate data from the Archivists’ Toolkit or Archon can start using Archivists 1.5.0 without the need of upgrading.  (People in this situation do not need to read any further.)
- 
+
 Converting the container data model in version 1.4.2 and earlier versions of ArchivesSpace to the 1.5.0 version has some complexity and may not accommodate all the various ways in which container information has been recorded by diverse repositories.  As a consequence, upgrading from a pre-1.5.0 version of ArchivesSpace requires planning for the upgrade, reviewing the results, and, possibly, remediating data either prior to or after the final conversion process.  Because of all the variations in which container information can be recorded, it is impossible to know all the ways the data of repositories will be impacted.  For this reason, **all repositories upgrading their ArchivesSpace to version 1.5.0 should do so with a backup of their production ArchivesSpace instance and in a test environment.** A conversion may only be undone by reverting back to the source database.
 
 ## Frequently Asked Questions
@@ -64,25 +64,25 @@ During the conversion, ArchivesSpace will find all the Container 1s in your curr
 * If your Container 1s have unique barcodes, you do not need to do anything except verify that your data is complete and accurate. You should run a preliminary conversion as described in the Conversion section and resolve any errors.
 * If your Container 1s do not have barcodes, but have a nonduplicative container identifier sequence within each accession or resource (e.g. Box 1, Box 2, Box 3), or the identifiers are only reused within an accession or resource for different types of containers (for example, you have a Box 1 through 10 and an Oversize Box 1 through 3) you do not need to do anything except verify that your data is complete and accurate. You should run a preliminary conversion as described in the Conversion section and resolve any errors.
 * If your Container 1s do not have barcodes and you have parallel numbering sequences, where the same indicators and types are used to refer to different containers within the same accession or resource within some or all accessions or resources (for example, you have a Box 1 in series 1 and a different Box 1 in series 5) you will need to find a way to uniquely identify these containers. One option is to run this [barcoder plugin](https://github.com/archivesspace/barcoder) for each resource to which this applies. The barcoder plugin creates barcodes that combine the ID of the highest level archival object ancestor with the container 1 type and indicator. (The barcoder plugin is designed to run against one resource at a time, instead of against all resources, because not all resources in a repository may match this condition.) Once you’ve differentiated your containers with parallel number sequences, you should run a preliminary conversion as described in the Conversion section and resolve any errors.
- 
+
 You do not need to make any changes to Container 2 fields or Container 3 fields. Data in these fields will be converted to the new Child and Grandchild container fields that map directly to these fields.
 
 If you use the current Container Extent fields, these will no longer be available in 1.5.0. Any data in these fields will be migrated to a new Extent sub-record during the conversion. You can evaluate whether this data should remain in an extent record or if it belongs in a container profile or other fields and then move it accordingly after the conversion is complete.
 
 *I have EADs I still need to import into ArchivesSpace. How can I get them ready for this new model?*
 
-If you have a box and folder associated with a component (or any other hierarchical relationship of containers), you will need to add identifiers to the container element so that the EAD importer knows which is the top container. If you previously used Archivists' Toolkit to create EAD, your containers probably already have container identifiers. If your container elements do not have identifiers already, Yale University has made available an [XSLT transformation file](https://github.com/YaleArchivesSpace/xslt-files/blob/master/EAD_add_IDs_to_containers.xsl) to add them. You will need to run it before importing the EAD file into ArchivesSpace. 
+If you have a box and folder associated with a component (or any other hierarchical relationship of containers), you will need to add identifiers to the container element so that the EAD importer knows which is the top container. If you previously used Archivists' Toolkit to create EAD, your containers probably already have container identifiers. If your container elements do not have identifiers already, Yale University has made available an [XSLT transformation file](https://github.com/YaleArchivesSpace/xslt-files/blob/master/EAD_add_IDs_to_containers.xsl) to add them. You will need to run it before importing the EAD file into ArchivesSpace.
 
-## Conversion <a name="conversion"></a> 
+## Conversion <a name="conversion"></a>
 
-When upgrading from 1.4.2 (and earlier versions) to 1.5.0, the container conversion will happen as part of the upgrade process. You will be able to follow its progress in the log. Instructions for upgrading from a previous version of ArchivesSpace are available at [https://github.com/archivesspace/archivesspace/blob/master/UPGRADING.md]. 
+When upgrading from 1.4.2 (and earlier versions) to 1.5.0, the container conversion will happen as part of the upgrade process. You will be able to follow its progress in the log. Instructions for upgrading from a previous version of ArchivesSpace are available at [https://github.com/archivesspace/archivesspace/blob/master/UPGRADING.md].
 
 Because this is a major change in the data model for this portion of the application, running at least one test conversion is very strongly recommended. Follow these steps to run the upgrade/conversion process:
 * Create a backup of your ArchivesSpace instance to use for testing. **IT IS ESSENTIAL THAT YOU NOT RUN THIS ON A PRODUCTION INSTANCE AS THE CONVERSION CHANGES YOUR DATA, and THE CHANGES CANNOT BE UNDONE EXCEPT BY REVERTING TO A BACKUP VERSION OF YOUR DATA PRIOR TO RUNNING THE CONVERSION.**
 * Follow the upgrade instructions to unpack a fresh copy of the v 1.5.0 release made available for testing, copy your configuration and data files, and transfer your locales.
 * **It is recommended that you delete your Solr index files to start with a fresh index** We are upgrading the version of Solr that ships with the application, and the upgrade will require a total reindex of your ArchivesSpace data. To do this, delete the data/solr_index/index directory and the files in data/indexer_state.  
 * Follow the upgrade instructions to run the database migrations. As part of this step, your container data will be converted to the new data model. You can follow along in the log. Windows users can open the archivesspace.out file in a tool like Notepad ++. Mac users can do a tail –f logs/archivesspace.out to get a live update from the log.
-* When the test conversion has been completed, the log will indicate "Completed: existing containers have been migrated to the new container model." 
+* When the test conversion has been completed, the log will indicate "Completed: existing containers have been migrated to the new container model."
 
  ![Image of Conversion Log](https://github.com/archivesspace/archivesspace/blob/master/docs/ConversionLog.png)
 
@@ -91,8 +91,8 @@ Retrieve the container conversion error report from the Background Jobs area:
 * Select Background Jobs from the Settings menu.
 
 ![Image of Background Jobs](https://github.com/archivesspace/archivesspace/blob/master/docs/BackgroundJobs.png)
- 
-* The first item listed under Archived Jobs after completing the upgrade should be container_conversion_job. Click View. 
+
+* The first item listed under Archived Jobs after completing the upgrade should be container_conversion_job. Click View.
 
 ![Image of Background Jobs List](https://github.com/archivesspace/archivesspace/blob/master/docs/BackgroundJobsList.png)
 
@@ -101,7 +101,7 @@ Retrieve the container conversion error report from the Background Jobs area:
 ![Image of Files](https://github.com/archivesspace/archivesspace/blob/master/docs/Files.png)
 
 ![Image of Error Report](https://github.com/archivesspace/archivesspace/blob/master/docs/ErrorReport.png)
- 
+
 * Go back to your source data and correct any errors that you can before doing another test conversion.
 * When the error report shows no errors, or when you are satisfied with the remaining errors, your production instance is ready to be upgraded.
 * When the final upgrade/conversion is complete, you can move ArchivesSpace version 1.5.0 into production.
@@ -113,7 +113,7 @@ Retrieve the container conversion error report from the Background Jobs area:
 * A container is missing a type or indicator.
 * Container levels are skipped (for example, there is a Container 1 and a Container 3, but no Container 2).
 * A container has multiple locations.
- 
+
 The conversion process can resolve some of these errors for you by supplying or deleting values as it deems appropriate, but for the most control over the process you will most likely want to resolve such issues yourself in your ArchivesSpace database before converting to the new container model.
 
 *Are there any known conversion issues?*

--- a/administration/upgrading/UPGRADING_2.1.0.md
+++ b/administration/upgrading/UPGRADING_2.1.0.md
@@ -1,4 +1,5 @@
-UPGRADING TO 2.1.0 (these considerations also apply when upgrading to any version past 2.1.0 from a version prior to 2.1.0)
+UPGRADING TO 2.1.0
+(these considerations also apply when upgrading to any version past 2.1.0 from a version prior to 2.1.0)
 
 ==================
 

--- a/development/docker.md
+++ b/development/docker.md
@@ -9,15 +9,15 @@ Run ArchivesSpace with MySQL, external Solr and a Web Proxy. Switch to the
 branch you want to build:
 
 ```bash
-# if you already have running containers and want to clear them out
+#if you already have running containers and want to clear them out
 docker-compose stop
 docker-compose rm
 
-# build the local image
+#build the local image
 docker-compose build # needed whenever the branch is changed and ready to test
 docker-compose up
 
-# running specific containers
+#running specific containers
 docker-compose up db solr web
 docker-compose run app bash # access app terminal
 ```

--- a/development/supervisord.md
+++ b/development/supervisord.md
@@ -12,13 +12,13 @@ From within the ArchivesSpace source directory:
 
 [sudo] pip install supervisor supervisor-stdout
 
-# run all of the services
+#run all of the services
 supervisord -c supervisord/archivesspace.conf
 
-# run in api mode (backend + indexer / solr only)
+#run in api mode (backend + indexer / solr only)
 supervisord -c supervisord/api.conf
 
-# run just the backend (useful for trying out endpoints that don't require Solr)
+#run just the backend (useful for trying out endpoints that don't require Solr)
 supervisord -c supervisord/backend.conf
 
 To stop supervisord: `Ctrl-c`.

--- a/migrations/migrate_from_archivists_toolkit.md
+++ b/migrations/migrate_from_archivists_toolkit.md
@@ -1,8 +1,8 @@
-# Migrating Data from Archivists’ Toolkit to ArchivesSpace Using the Migration Tool
+# Migrating Data from Archivists' Toolkit to ArchivesSpace Using the Migration Tool
 
-These guidelines are for migrating data from Archivists’ Toolkit 2.0 Update 16 to all ArchivesSpace 2.1.x or 2.2.x releases using the migration tool provided by ArchivesSpace. Migrations of data from earlier versions of the Archivists’ Toolkit (AT) or other versions of ArchivesSpace are not supported by these guidelines or migration tool.
+These guidelines are for migrating data from Archivists' Toolkit 2.0 Update 16 to all ArchivesSpace 2.1.x or 2.2.x releases using the migration tool provided by ArchivesSpace. Migrations of data from earlier versions of the Archivists' Toolkit (AT) or other versions of ArchivesSpace are not supported by these guidelines or migration tool.
 
-> Note: A migration from Archivists’ Toolkit to ArchivesSpace should not be run against an active production database.
+> Note: A migration from Archivists' Toolkit to ArchivesSpace should not be run against an active production database.
 
 ## Preparing for migration
 
@@ -14,7 +14,7 @@ These guidelines are for migrating data from Archivists’ Toolkit 2.0 Update 16
 
 ### Notes
 
-* An AT subject record will be set to type ‘topical’ if it does not have a valid AT type statement or its type is not one of the types in ArchivesSpace. Several other AT LookupList values are not present in ArchivesSpace. These LookupList values cannot be added during the AT migration process and will therefore need to be changed in AT prior to migration. For full details on enum (controlled value list) mappings see the data map. You can use the AT Lookup List tool to change values that will not map correctly, as specified by the data map.
+* An AT subject record will be set to type ‘topical' if it does not have a valid AT type statement or its type is not one of the types in ArchivesSpace. Several other AT LookupList values are not present in ArchivesSpace. These LookupList values cannot be added during the AT migration process and will therefore need to be changed in AT prior to migration. For full details on enum (controlled value list) mappings see the data map. You can use the AT Lookup List tool to change values that will not map correctly, as specified by the data map.
 
 * Record audit information (created by, date created, modified by, and date modified) will not migrate from AT to ArchivesSpace. ArchivesSpace will assign new audit data to each record as it is imported into ArchivesSpace. The exception to this is that the username of the user who creates an accession record will be migrated to the accession general note field.
 
@@ -47,7 +47,7 @@ installation directory.
 
 ## Running the Migration Tool as an AT Plugin
 
-* Make sure that the AT instance you want to migrate from is shut down. Next, download the “scriptAT.zip” file from the at-migration release github page (https://github.com/archivesspace/at-migration/releases) and copy the file into the plugins folder of the AT instance, overwriting the one that’s already there if needed.
+* Make sure that the AT instance you want to migrate from is shut down. Next, download the “scriptAT.zip” file from the at-migration release github page (https://github.com/archivesspace/at-migration/releases) and copy the file into the plugins folder of the AT instance, overwriting the one that's already there if needed.
 
 * Make sure the ArchivesSpace instance that you are migrating into is up and running.
 
@@ -162,4 +162,4 @@ If you accept the migration in the ArchivesSpace instance, the following outline
 
 * Take special care to check to make sure your container data and locations are correct. The model for this is significantly different between AT and ArchivesSpace (where locations are tied to a container rather than directly to a resource or accession), so this presents some challenges for migration.
 
-* Merge enumeration values as necessary. For instance, if you had both ‘local’ and ‘local sources’ as a source for names, it might be a good idea to merge these values.
+* Merge enumeration values as necessary. For instance, if you had both ‘local' and ‘local sources' as a source for names, it might be a good idea to merge these values.

--- a/provisioning/clustering.md
+++ b/provisioning/clustering.md
@@ -75,7 +75,7 @@ The highlights:
   * `/aspace/nginx/conf/tenants/[tenant name].conf` -- A tenant-specific Nginx configuration file.  Used to set the URLs of each tenant's ArchivesSpace instances.
 
 
-# Getting started
+## Getting started
 
 We'll assume you already have the following ready to go:
 
@@ -95,7 +95,7 @@ We'll assume you already have the following ready to go:
   * Java 1.6 (or above) installed on each machine.
 
 
-## Populate your /aspace/ directory
+### Populate your /aspace/ directory
 
 Start by copying the directory structure from `files/` into your
 `/aspace` volume.  This will contain all of the configuration files
@@ -110,7 +110,7 @@ You can do this on any machine that has access to the shared
 `/aspace/` volume.
 
 
-## Install the cluster init script
+### Install the cluster init script
 
 On your application servers (`apps1` and `apps2`) you will need to
 install the supplied init script:
@@ -122,7 +122,7 @@ This will start all configured instances when the system boots up, and
 can also be used to start/stop individual instances.
 
 
-## Install and configure Nginx
+### Install and configure Nginx
 
 You will need to install Nginx on your `loadbalancer` machine, which
 you can do by following the directions at
@@ -145,7 +145,7 @@ tenants' configuration files.  To do this, edit
 systems.  Another likely candidate is `/etc/nginx/nginx.conf`.
 
 
-## Download the ArchivesSpace distribution
+### Download the ArchivesSpace distribution
 
 Rather than having every tenant maintain their own copy of the
 ArchivesSpace software, we put a shared copy under
@@ -172,7 +172,7 @@ the ArchivesSpace package:
      wget http://repo1.maven.org/maven2/mysql/mysql-connector-java/5.1.24/mysql-connector-java-5.1.24.jar
 
 
-# Defining a new tenant
+## Defining a new tenant
 
 With our server setup out of the way, we're ready to define our first
 tenant.  As shown in *Overview of files* above, each tenant has their
@@ -210,7 +210,7 @@ information you will need.  In particular, you will need to know:
     for the public interface.
 
 
-## Creating a Unix account
+### Creating a Unix account
 
 Although not strictly required, for security and ease of system
 monitoring it's a good idea to have each tenant instance running under
@@ -227,7 +227,7 @@ Note that we specify a UID and GID explicitly to ensure they match
 across machines.
 
 
-## Creating the database
+### Creating the database
 
 ArchivesSpace assumes that each tenant will have their own MySQL
 database.  You can create this from the MySQL shell:
@@ -245,7 +245,7 @@ the database URL:
 We'll make use of this URL in the following section.
 
 
-## Creating the tenant configuration
+### Creating the tenant configuration
 
 Each tenant has their own set of files under the
 `/aspace/archivesspace/tenants/` directory.  We'll define our new
@@ -273,7 +273,7 @@ which should be random, hard to guess passwords.
 
 
 
-# Adding the tenant instances
+## Adding the tenant instances
 
 To add our tenant instances, we just need to initialize them on each
 of our servers.  On `apps1` *and* `apps2`, we run:
@@ -315,7 +315,7 @@ it starts up, and are also used by the ArchivesSpace indexing system
 to track updates across the cluster.
 
 
-## Starting up
+### Starting up
 
 As a one-off, we need to populate this tenant's database with the
 default set of tables.  You can do this by running the
@@ -335,7 +335,7 @@ you should be able to connect to each instance with your web browser
 at the configured URLs.
 
 
-# Configuring the load balancer
+## Configuring the load balancer
 
 Our final step is configuring Nginx to accept requests for our staff
 and public interfaces and forward them to the appropriate application


### PR DESCRIPTION
In order to create the technical documentation static HTML pages, needed to remove "smart" single quotes from migrations/migrate_from_archivists_toolkit.md.

Also, in the other files, needed to change the way hash tags (#) are in the files to ensure that appropriate sub static pages are created.