### PR TITLE
Documenting deprecated OAI-PMH settings for release 2.5.2

### DIFF
--- a/customization/configuration.md
+++ b/customization/configuration.md
@@ -242,33 +242,23 @@ Resist the urge to set this to a big number!
 
 ### OAI configuration options
 
-#### `AppConfig[:oai_repository_name]`
-
-> TODO - Needs more documentation
-
-`AppConfig[:oai_repository_name] = 'ArchivesSpace OAI Provider'`
-
-
-
 #### `AppConfig[:oai_proxy_url]`
 
 > TODO - Needs more documentation
 
 `AppConfig[:oai_proxy_url] = 'http://your-public-oai-url.example.com'`
 
+**NOTE: As of version 2.5.2, the following parameters (oai_repository_name, oai_record_prefix, and oai_admin_email) have been deprecated. They should be set in the Staff User Interface. To set them, select the System menu in the Staff User Interface and then select Manage OAI-PMH Settings. These three settings are at the top of the page in the General Settings section. These settings will be completely removed from the config file when version 2.6.0 is released.**
 
+#### `AppConfig[:oai_repository_name]`
+
+`AppConfig[:oai_repository_name] = 'ArchivesSpace OAI Provider'`
 
 #### `AppConfig[:oai_record_prefix]`
 
-> TODO - Needs more documentation
-
 `AppConfig[:oai_record_prefix] = 'oai:archivesspace'`
 
-
-
 #### `AppConfig[:oai_admin_email]`
-
-> TODO - Needs more documentation
 
 `AppConfig[:oai_admin_email] = 'admin@example.com'`
 


### PR DESCRIPTION
Three OAI-PMH settings have been moved out of the config file to make them easier for the folks managing repositories to set them. They will be kept in the config file with a note stating deprecated for 2.5.2 but will be removed from the config file in 2.6.0. Hopefully, that will make the change more obvious when upgrading. Please improve the wording of the note if it is not clear.