### PR TITLE
Clarify building API docs only, indicate necesary bundler version, typos

### DIFF
--- a/development/build.md
+++ b/development/build.md
@@ -17,7 +17,7 @@ The bootstrap task:
 Will bootstrap your development environment by downloading all
 dependencies--JRuby, Gems, Solr, etc..
 
-## Running components indiviually
+## Running components individually
 
 To run a development instance of all ArchivesSpace components:
 

--- a/development/release.md
+++ b/development/release.md
@@ -53,7 +53,7 @@ script that rips apart the READMEs. Also, links in the site's side bar need to b
 added to [Jekyll's
 sidebar](https://github.com/archivesspace/archivesspace/blob/master/docs/_includes/sidebar.html).
 
-Before the `build/run doc:build` step, but sure you run the `build/run backend:test` step. This will run all your tests, including the documentation_spec.rb spec, which runs through all the endpoints, generates factory girl fixture json, and spits it into a json file ( endpoint_examples.json ).
+Before the `build/run doc:build` step, be sure you run the `build/run backend:test` step. This will run all your tests, including the documentation_spec.rb spec, which runs through all the endpoints, generates factory bot fixture json, and spits it into a json file (endpoint_examples.json).
 
 To build the documentation:
 
@@ -74,23 +74,26 @@ To build the documentation:
 ```
   $ build/run backend:test
 ```
+Alternatively, if only updating the API docs
+```
+  $ build/run backend:test -Dspec='documentation_spec.rb'
+```
 
-5. Update the fallback_version value in common/asconstants.rb with the new version number so that the documentation with have the correct version number in the footer
+5. Update the fallback_version value in common/asconstants.rb with the new version number so that the documentation will have the correct version number in the footer
 ```
   fallback_version = "vX.X.X.a"
 ```
 
 6. Rip apart the READMEs for content by running the doc:build ANT task
-
 ```
   $ build/run doc:build
 ```
 
-7. Build Slate ( using a standard Ruby )
-
+7. Build Slate/API docs (using a standard Ruby)
+  *Note*: At present, middleman requires a bundler version < 2.0 so the docs have been updated to reflect this.
 ```
   $ cd docs/slate
-  $ gem install bundler
+  $ gem install bundler --version '< 2.0'
   $ bundle install --binstubs
   $ ./bin/middleman build
   $ ./bin/middleman server # optional if you want to have a look at the site.
@@ -99,7 +102,6 @@ To build the documentation:
 ```
 
 8. Compile Jekyll
-
 ```
   $ cd docs
   $ gem install bundler
@@ -109,14 +111,13 @@ To build the documentation:
 ```
 
 9. Commit the docs directory to git then push it to the gh-pages branch
-
 ```
-$ cd ../ # go to top of the working tree
-$ git add # all files related to the docs that just got created/updated (eg. docs/*, index.html files, etc) (do NOT add common/asconstants.rb)
-$ git commit # with appropriate commit message
-$  git subtree push --prefix docs origin gh-pages
-( or, if you get a FF error )
-$ git push origin `git subtree split --prefix docs master`:gh-pages --force
+  $ cd ../ # go to top of the working tree
+  $ git add # all files related to the docs that just got created/updated (eg. docs/*, index.html files, etc) (do NOT add common/asconstants.rb)
+  $ git commit # with appropriate commit message
+  $  git subtree push --prefix docs origin gh-pages
+  ( or, if you get a FF error )
+  $ git push origin `git subtree split --prefix docs master`:gh-pages --force
 ```
 
 10. Now merge in the docs directory back into master by committing the new-document


### PR DESCRIPTION
A few changes to improve documentation on building/testing just the API docs (Slate).  Also, indicating that middleman doesn't like bundler 2+.  Finally, fixing a few typos.