### PR TITLE
Cleanup comments and add some post-release steps

### DIFF
--- a/administration/indexes.md
+++ b/administration/indexes.md
@@ -31,9 +31,9 @@ accessions in repository 2 delete the file called `2_accession.dat`.
 If you update a record's `system_mtime` it becomes eligible for reindexing.
 
 ```sql
-# reindex all resources
+#reindex all resources
 UPDATE resource SET system_mtime = NOW();
-# reindex resource 1
+#reindex resource 1
 UPDATE resource SET system_mtime = NOW() WHERE id = 1;
 ```
 

--- a/api/README.md
+++ b/api/README.md
@@ -34,13 +34,13 @@ This will return a JSON response that includes something like the following:
 It’s a good idea to save the session key as an environment variable to use for later requests:
 
 ```
-# Mac/Unix terminal
+#Mac/Unix terminal
 export SESSION="9528190655b979f00817a5d38f9daf07d1686fed99a1d53dd2c9ff2d852a0c6e"
 
-# Windows Command Prompt
+#Windows Command Prompt
 set SESSION="9528190655b979f00817a5d38f9daf07d1686fed99a1d53dd2c9ff2d852a0c6e"
 
-# Windows PowerShell
+#Windows PowerShell
 $env:SESSION="9528190655b979f00817a5d38f9daf07d1686fed99a1d53dd2c9ff2d852a0c6e"
 ```
 

--- a/development/release.md
+++ b/development/release.md
@@ -93,6 +93,7 @@ cd docs/slate
 gem install bundler --version '< 2.0'
 bundle install --binstubs
 ./bin/middleman build
+./bin/middleman server # optional if you want to have a look at the API docs only
 rm -r ../api
 mv build ../api
 ```
@@ -128,9 +129,9 @@ git commit -m "Updating to vX.X.X"
 11. Push docs to the gh-pages branch (do not do this with release candidates)
 
 ```
-# SKIP THIS PUSH STEP FOR RELEASE CANDIDATES
+#SKIP THIS PUSH STEP FOR RELEASE CANDIDATES
 git subtree push --prefix docs origin gh-pages
-# or, if you get a FF error
+#or, if you get a FF error
 git push origin `git subtree split --prefix docs master`:gh-pages --force
 ```
 
@@ -167,7 +168,7 @@ changes for the release.
 
 ```
 bundle exec rake release_notes:generate[$previous_release_tag,$new_release_tag]
-# example:
+#example:
 bundle exec rake release_notes:generate[v2.7.1,v2.8.0-rc1]
 ```
 
@@ -186,7 +187,7 @@ Significant changes to be the config file should be called out. To get the chang
 
 ```
 git diff $previous_version..$new_version -- common/config/config-defaults.rb
-# example
+#example
 git diff v2.7.1..v2.8.0-rc1 -- common/config/config-defaults.rb
 ```
 
@@ -217,7 +218,7 @@ Get the latest schema version:
 
 ```
 git diff --name-only $previous_version..$new_version | grep "common/db/migrations"
-# example
+#example
 git diff --name-only v2.7.1..v2.8.0-rc1 | grep "common/db/migrations"
 ```
 
@@ -227,7 +228,7 @@ to techdocs. Only do the latter for a release, not release candidates.
 Update the release notes under 'Database migrations' add:
 
 ```
-# $n = no. of lines from git diff above, $x = the no. on the last line
+#$n = no. of lines from git diff above, $x = the no. on the last line
 This release includes $n new database migrations. The schema number for this release is $x.
 ```
 
@@ -259,6 +260,21 @@ cycle of development clicks into full gear:
 ### Branches
 
 Delete merged and stale branches in Github as appropriate.
+
+### Test Servers
+
+Review existing test servers, and request the removal of any that are no longer
+needed (e.g. feature branches that have been merged for the release).
+
+### Accessibility Scan
+
+Run accessibility scans for both the public and staff sites and file a ticket
+for any new and ongoing accessibility errors.
+
+### PR Assignments
+
+Begin assigning queued PRs to members of the Core Committers group, making
+sure to include the appropriate milestone for the anticipated next release.
 
 ### Dependencies
 

--- a/development/ui_test.md
+++ b/development/ui_test.md
@@ -34,14 +34,14 @@ Note: all example code assumes you are running from your ArchivesSpace project d
 ## Running the tests:
 
 ```bash
-# Frontend tests
+#Frontend tests
 ./build/run frontend:selenium # Firefox, headless
 FIREFOX_OPTS= ./build/run frontend:selenium # Firefox, no-opts = heady
 
 SELENIUM_CHROME=true ./build/run frontend:selenium # Chrome, headless
 SELENIUM_CHROME=true CHROME_OPTS= ./build/run frontend:selenium # Chrome, no-opts = heady
 
-# Public tests
+#Public tests
 ./build/run public:test # Firefox, headless
 FIREFOX_OPTS= ./build/run public:test # Firefox, no-opts = heady
 
@@ -55,7 +55,7 @@ Tests can be scoped to specific files or groups:
 ./build/run .. -Dspec='path/to/spec/from/spec/directory' # single file
 ./build/run .. -Dexample='[description from it block]' # specific block
 
-# EXAMPLES
+#EXAMPLES
 ./build/run frontend:selenium -Dexample='Repository model'
 FIREFOX_OPTS= ./build/run frontend:selenium -Dexample='Repository model'# Firefox, heady
 


### PR DESCRIPTION
Added a few more items to Post-Release steps in `development/release.md`.

Also found/removed all instances of lines beginning with single #'s inside of codeblocks, such as:

````
```
# Something something
```
````

as these cause the docs build process to abruptly end a page at the # and begin a new stub of a docs page following the #.  