### PR TITLE
additional links and plugin text migrated from deprecated Confluence …

### DIFF
--- a/customization/plugins.md
+++ b/customization/plugins.md
@@ -9,6 +9,8 @@ sharing of packages of customization between ArchivesSpace instances.
 
 The ArchivesSpace distribution comes with the `hello_world` exemplar plug-in. Please refer to its [README file](https://github.com/archivesspace/archivesspace/blob/master/plugins/hello_world/README.md) for a detailed description of how it is constructed and implemented.
 
+You can find other examples in the following plugin repositories. The ArchivesSpace plugins that are officially supported and maintained by the ArchivesSpace Program Team are in archivesspace-plugins (https://github.com/archivesspace-plugins). Deprecated code which is no longer supported but has been kept for future reference is in archivesspace-deprecated (https://github.com/archivesspace-deprecated). There is an open/unmanaged GitHub repository where community members can share their code called archivesspace-labs (https://github.com/archivesspace-labs). The community developed Python library for interacting with the ArchivesSpace API, called ArchivesSnake, is managed in the archivesspace-labs repository.
+
 ## Enabling plugins
 
 Plug-ins are enabled by placing them in the `plugins` directory, and referencing them in the

--- a/readme_develop.md
+++ b/readme_develop.md
@@ -19,8 +19,18 @@ This information will be useful for those creating ArchivesSpace plugins, contri
 * [Customizing text in ArchivesSpace](./customization/locales.md)
 * [Theming ArchivesSpace](./customization/theming.md)
 * [Managing frontend assets with Bower](./customization/bower.md)
-  
+
 ## Exporting data from ArchivesSpace
 * [ArchivesSpace repository EAD Exporter](./import_export/ead_exporter.md)
 * [ArchivesSpace XSL stylesheets](./import_export/xsl_stylesheets.md)
 * [Creating Custom Reports](./customization/reports.md)
+
+## Repositories and CoC
+* [Code of Conduct](https://github.com/archivesspace/archivesspace/blob/master/CODE_OF_CONDUCT.md)
+* [Main ArchivesSpace Repository](https://github.com/archivesspace/archivesspace)
+* [Plugins supported by the Program Team](https://github.com/archivesspace-plugins)
+* [Repository for community development projects](https://github.com/archivesspace-labs)
+* [Program Team's Youtube channel](https://www.youtube.com/channel/UCxR6D-UlSx6N6UWTeqHTjzA)
+* [Hudson Molonglo's Youtub channel](https://www.youtube.com/channel/UCMBmBY_CsxwJy9rJKxQrVoQ)
+* [Sandbox - latest release](http://sandbox.archivesspace.org/)
+* [Test Server - latest commit](http://test.archivesspace.org/)


### PR DESCRIPTION
…development docs

Part 1 of 2 containing some content from developer documentation that was in Confluence but has been retired by the Core Committer group so that this repo can claim absolute authority.

Please suggest any changes or additions / subtractions.