### PR TITLE
Update config path in plugins doc example

### DIFF
--- a/customization/plugins.md
+++ b/customization/plugins.md
@@ -12,7 +12,7 @@ The ArchivesSpace distribution comes with the `hello_world` exemplar plug-in. Pl
 ## Enabling plugins
 
 Plug-ins are enabled by placing them in the `plugins` directory, and referencing them in the
-ArchivesSpace configuration, `config/config.rb`. For example:
+ArchivesSpace configuration, `common/config/config.rb`. For example:
 
     AppConfig[:plugins] = ['local', 'hello_world', 'my_plugin']
 


### PR DESCRIPTION
This PR updates the path to the ArchivesSpace config file in the plugin customization docs. The location of the config file has changed to the [common/ directory](https://github.com/archivesspace/archivesspace/tree/master/common/config).