### PR TITLE
Fixing broken link for external solr

### DIFF
--- a/administration/getting_started.md
+++ b/administration/getting_started.md
@@ -19,7 +19,7 @@ versions provided an embedded Solr v4 instance, which was removed due to
 being old and unsupported, with very limited scope for enhancements over
 time).
 
-[Running ArchivesSpace with external Solr](./provisioning/solr.md) (Version 3.2+)
+[Running ArchivesSpace with external Solr](../provisioning/solr.md) (Version 3.2+)
 
 ## Getting started
 


### PR DESCRIPTION
Looks like an incorrect path was introduced on this one, though it's correct further down in the document.