### PR TITLE
Fix 404's on home page

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,9 +6,9 @@ permalink: /
 
 The technical documentation covers a range of topics of interest to those working with ArchivesSpace in different technical capacities, and is organized in order to help you find the information most appropriate to your role.
 
-- **[ArchivesSpace technical overview](./readme_evaluate.md)** – For anyone who needs to evaluate technical requirements and capabilities of ArchivesSpace
-- **[Installing, configuring and maintaining an ArchivesSpace instance](./readme_implement.md)** – For anyone responsible for installing and/or maintaining an ArchivesSpace instance
-- **[Developer resources](./readme_develop.md)** – For anyone who needs to create plugins, integrate ArchivesSpace with other systems, or contribute to core code
+- **[ArchivesSpace technical overview](./readme_evaluate)** – For anyone who needs to evaluate technical requirements and capabilities of ArchivesSpace
+- **[Installing, configuring and maintaining an ArchivesSpace instance](./readme_implement)** – For anyone responsible for installing and/or maintaining an ArchivesSpace instance
+- **[Developer resources](./readme_develop)** – For anyone who needs to create plugins, integrate ArchivesSpace with other systems, or contribute to core code
 
 **To suggest corrections or additions, please submit a pull request or issue report on [Github](https://github.com/archivesspace/tech-docs)**
 


### PR DESCRIPTION
Fixes links from home page that results in 404 errors, by removing the `.md` extensions.

The three broken links on the home page are:

https://archivesspace.github.io/tech-docs/readme_evaluate.md

https://archivesspace.github.io/tech-docs/readme_implement.md

https://archivesspace.github.io/tech-docs/readme_develop.md