### PR TITLE
Drop confusing link to master version of configs

### DIFF
--- a/provisioning/solr.md
+++ b/provisioning/solr.md
@@ -75,8 +75,6 @@ d-----        10/25/2021  12:15 PM                conf
 Copy the ArchivesSpace Solr configuration files from the `solr` directory included
 with the release into the `$SOLR_HOME/server/solr/configsets/archivesspace/conf` directory.
 
-[Link to files in GitHub](https://github.com/archivesspace/archivesspace/tree/master/solr)
-
 There should be four files:
 
 - schema.xml


### PR DESCRIPTION
This link was to mast and if someone uses those versions they're going to have a bad time unless they're lucky enough to have that same version of ArchivesSpace running. No need to link to them here it's just confusing.