### PR TITLE
TD-17 Update branch name in github editLink url

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -15,8 +15,7 @@ export default defineConfig({
       },
       customCss: ['./src/styles/custom.css'],
       editLink: {
-        baseUrl:
-          'https://github.com/archivesspace/tech-docs/edit/astro-starlight/'
+        baseUrl: 'https://github.com/archivesspace/tech-docs/edit/master/'
       },
       credits: true,
       lastUpdated: true,


### PR DESCRIPTION
This PR updates the "edit this page on GitHub" link url in the Astro config since the new site has now been merged into master.

The production branch in the Cloudflare settings have also been updated accordingly, so Cloudflare will start building from master once this PR gets merged.

After this PR is merged and Cloudflare is confirmed to be working as expected, the `astro-starlight` branch can be deleted.

[TD-17](https://archivesspace.atlassian.net/browse/TD-17)

[TD-17]: https://archivesspace.atlassian.net/browse/TD-17?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ