### PR TITLE
TD-29 Change default branch to main

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -15,7 +15,7 @@ export default defineConfig({
       },
       customCss: ['./src/styles/custom.css'],
       editLink: {
-        baseUrl: 'https://github.com/archivesspace/tech-docs/edit/master/'
+        baseUrl: 'https://github.com/archivesspace/tech-docs/edit/main/'
       },
       credits: true,
       lastUpdated: true,


### PR DESCRIPTION
This PR updates the codebase to reflect the default branch change to `main` that occurred on 2025-01-21.

In addition to the Astro config file changed herein, branch info was updated in this repo's GitHub and Cloudflare settings.

[TD-29](https://archivesspace.atlassian.net/browse/TD-29)

[TD-29]: https://archivesspace.atlassian.net/browse/TD-29?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ