### PR TITLE
TD-31: Add release badge for the latest ArchivesSpace release

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -27,6 +27,8 @@ export default defineConfig({
       tableOfContents: { minHeadingLevel: 2, maxHeadingLevel: 4 },
       components: {
         Footer: './src/components/overrides/Footer.astro',
+        Header: './src/components/overrides/Header.astro',
+        MobileMenuFooter: './src/components/overrides/MobileMenuFooter.astro',
         Sidebar: './src/components/overrides/Sidebar.astro',
         SocialIcons: './src/components/overrides/SocialIcons.astro'
       }

--- a/cypress/e2e/release-badge.cy.js
+++ b/cypress/e2e/release-badge.cy.js
@@ -1,0 +1,38 @@
+const releaseUrl =
+  'https://github.com/archivesspace/archivesspace/releases/latest'
+const title = 'Go to the latest ArchivesSpace release'
+const badgeSrc = `https://img.shields.io/github/v/release/archivesspace/archivesspace?label=ArchivesSpace&color=007595`
+const altText = 'The latest ArchivesSpace release version'
+
+describe('Release Badge', () => {
+  it('displays the release badge with the correct data in the header on desktop', () => {
+    cy.visit('/')
+    cy.get(
+      '.page > header:first-child > div:first-child > div:nth-child(3) > a:first-child'
+    )
+      .should('have.attr', 'href', releaseUrl)
+      .should('have.attr', 'title', title)
+      .within(() => {
+        cy.get('img')
+          .should('have.attr', 'src', badgeSrc)
+          .should('have.attr', 'alt', altText)
+      })
+  })
+
+  it(
+    'displays the release badge with the correct data in the mobile menu footer',
+    { viewportWidth: 400 },
+    () => {
+      cy.visit('/')
+      cy.get('button[aria-label="Menu"]').click()
+      cy.get('#starlight__sidebar .mobile-preferences > a:first-child')
+        .should('have.attr', 'href', releaseUrl)
+        .should('have.attr', 'title', title)
+        .within(() => {
+          cy.get('img')
+            .should('have.attr', 'src', badgeSrc)
+            .should('have.attr', 'alt', altText)
+        })
+    }
+  )
+})

--- a/src/components/ReleaseBadge.astro
+++ b/src/components/ReleaseBadge.astro
@@ -1,0 +1,28 @@
+---
+const releaseUrl =
+  'https://github.com/archivesspace/archivesspace/releases/latest'
+const label = 'ArchivesSpace'
+const color = '007595' // dark `--sl-color-accent` via custom.css
+const badgeSrc = `https://img.shields.io/github/v/release/archivesspace/archivesspace?label=${label}&color=${color}`
+const altText = 'The latest ArchivesSpace release version'
+const title = 'Go to the latest ArchivesSpace release'
+---
+
+<a href={releaseUrl} title={title}>
+  <img alt={altText} src={badgeSrc} />
+</a>
+
+<style>
+  a {
+    display: flex;
+    align-items: center;
+    gap: 1rem;
+  }
+  @media (min-width: 800px) {
+    a::after {
+      content: '';
+      height: 2rem;
+      border-inline-end: 1px solid var(--as-color-hairline);
+    }
+  }
+</style>

--- a/src/components/overrides/Header.astro
+++ b/src/components/overrides/Header.astro
@@ -1,0 +1,101 @@
+---
+import config from 'virtual:starlight/user-config'
+import type { Props } from '../props'
+
+import LanguageSelect from 'virtual:starlight/components/LanguageSelect'
+import Search from 'virtual:starlight/components/Search'
+import SiteTitle from 'virtual:starlight/components/SiteTitle'
+import SocialIcons from 'virtual:starlight/components/SocialIcons'
+import ThemeSelect from 'virtual:starlight/components/ThemeSelect'
+
+/**
+ * Render the `Search` component if Pagefind is enabled or the default search component has been overridden.
+ */
+const shouldRenderSearch =
+  config.pagefind ||
+  config.components.Search !== '@astrojs/starlight/components/Search.astro'
+---
+
+<div class="header sl-flex">
+  <div class="title-wrapper sl-flex">
+    <SiteTitle {...Astro.props} />
+  </div>
+  <div class="sl-flex print:hidden">
+    {shouldRenderSearch && <Search {...Astro.props} />}
+  </div>
+  <div class="sl-hidden md:sl-flex print:hidden right-group">
+    <div class="sl-flex social-icons">
+      <SocialIcons {...Astro.props} />
+    </div>
+    <ThemeSelect {...Astro.props} />
+    <LanguageSelect {...Astro.props} />
+  </div>
+</div>
+
+<style>
+  .header {
+    gap: var(--sl-nav-gap);
+    justify-content: space-between;
+    align-items: center;
+    height: 100%;
+  }
+
+  .title-wrapper {
+    /* Prevent long titles overflowing and covering the search and menu buttons on narrow viewports. */
+    overflow: clip;
+    /* Avoid clipping focus ring around link inside title wrapper. */
+    padding: 0.25rem;
+    margin: -0.25rem;
+    min-width: 0;
+  }
+
+  .right-group,
+  .social-icons {
+    gap: 1rem;
+    align-items: center;
+  }
+  .social-icons::after {
+    content: '';
+    height: 2rem;
+    border-inline-end: 1px solid var(--sl-color-gray-5);
+  }
+
+  @media (min-width: 50rem) {
+    :global(:root[data-has-sidebar]) {
+      --__sidebar-pad: calc(2 * var(--sl-nav-pad-x));
+    }
+    :global(:root:not([data-has-toc])) {
+      --__toc-width: 0rem;
+    }
+    .header {
+      --__sidebar-width: max(
+        0rem,
+        var(--sl-content-inline-start, 0rem) - var(--sl-nav-pad-x)
+      );
+      --__main-column-fr: calc(
+        (
+            100% + var(--__sidebar-pad, 0rem) -
+              var(--__toc-width, var(--sl-sidebar-width)) -
+              (2 * var(--__toc-width, var(--sl-nav-pad-x))) -
+              var(--sl-content-inline-start, 0rem) - var(--sl-content-width)
+          ) /
+          2
+      );
+      display: grid;
+      grid-template-columns:
+        /* 1 (site title): runs up until the main content column’s left edge or the width of the title, whichever is the largest  */
+        minmax(
+          calc(
+            var(--__sidebar-width) +
+              max(0rem, var(--__main-column-fr) - var(--sl-nav-gap))
+          ),
+          auto
+        )
+        /* 2 (search box): all free space that is available. */
+        1fr
+        /* 3 (right items): use the space that these need. */
+        auto;
+      align-content: center;
+    }
+  }
+</style>

--- a/src/components/overrides/Header.astro
+++ b/src/components/overrides/Header.astro
@@ -1,12 +1,15 @@
 ---
-import config from 'virtual:starlight/user-config'
-import type { Props } from '../props'
+// Via https://github.com/withastro/starlight/blob/23bf960aed36445600b6ccecb2138a5b461e2929/packages/starlight/components/Header.astro
 
-import LanguageSelect from 'virtual:starlight/components/LanguageSelect'
-import Search from 'virtual:starlight/components/Search'
-import SiteTitle from 'virtual:starlight/components/SiteTitle'
-import SocialIcons from 'virtual:starlight/components/SocialIcons'
-import ThemeSelect from 'virtual:starlight/components/ThemeSelect'
+import config from 'virtual:starlight/user-config'
+import type { Props } from '@astrojs/starlight/props'
+
+import LanguageSelect from '@astrojs/starlight/components/LanguageSelect.astro'
+import Search from '@astrojs/starlight/components/Search.astro'
+import SiteTitle from '@astrojs/starlight/components/SiteTitle.astro'
+import ReleaseBadge from '../ReleaseBadge.astro'
+import SocialIcons from './SocialIcons.astro'
+import ThemeSelect from '@astrojs/starlight/components/ThemeSelect.astro'
 
 /**
  * Render the `Search` component if Pagefind is enabled or the default search component has been overridden.
@@ -24,6 +27,7 @@ const shouldRenderSearch =
     {shouldRenderSearch && <Search {...Astro.props} />}
   </div>
   <div class="sl-hidden md:sl-flex print:hidden right-group">
+    <ReleaseBadge />
     <div class="sl-flex social-icons">
       <SocialIcons {...Astro.props} />
     </div>

--- a/src/components/overrides/MobileMenuFooter.astro
+++ b/src/components/overrides/MobileMenuFooter.astro
@@ -1,0 +1,33 @@
+---
+import LanguageSelect from 'virtual:starlight/components/LanguageSelect'
+import SocialIcons from 'virtual:starlight/components/SocialIcons'
+import ThemeSelect from 'virtual:starlight/components/ThemeSelect'
+import type { Props } from '../props'
+---
+
+<div class="mobile-preferences sl-flex">
+  <div class="sl-flex social-icons">
+    <SocialIcons {...Astro.props} />
+  </div>
+  <ThemeSelect {...Astro.props} />
+  <LanguageSelect {...Astro.props} />
+</div>
+
+<style>
+  .social-icons {
+    margin-inline-end: auto;
+    gap: 1rem;
+    align-items: center;
+    padding-block: 1rem;
+  }
+  .social-icons:empty {
+    display: none;
+  }
+  .mobile-preferences {
+    justify-content: space-between;
+    flex-wrap: wrap;
+    border-top: 1px solid var(--sl-color-gray-6);
+    column-gap: 1rem;
+    padding: 0.5rem 0;
+  }
+</style>

--- a/src/components/overrides/MobileMenuFooter.astro
+++ b/src/components/overrides/MobileMenuFooter.astro
@@ -1,11 +1,15 @@
 ---
-import LanguageSelect from 'virtual:starlight/components/LanguageSelect'
-import SocialIcons from 'virtual:starlight/components/SocialIcons'
-import ThemeSelect from 'virtual:starlight/components/ThemeSelect'
-import type { Props } from '../props'
+// Via https://github.com/withastro/starlight/blob/490c6eff34ab408c4f55777b7b0caa16787dd3d4/packages/starlight/components/MobileMenuFooter.astro
+
+import type { Props } from '@astrojs/starlight/props'
+import LanguageSelect from '@astrojs/starlight/components/LanguageSelect.astro'
+import ReleaseBadge from '../ReleaseBadge.astro'
+import SocialIcons from './SocialIcons.astro'
+import ThemeSelect from '@astrojs/starlight/components/ThemeSelect.astro'
 ---
 
 <div class="mobile-preferences sl-flex">
+  <ReleaseBadge />
   <div class="sl-flex social-icons">
     <SocialIcons {...Astro.props} />
   </div>

--- a/src/utils/gitMetadata.mjs
+++ b/src/utils/gitMetadata.mjs
@@ -1,5 +1,5 @@
-import { exec } from 'child_process'
-import { promisify } from 'util'
+import { exec } from 'node:child_process'
+import { promisify } from 'node:util'
 
 const execPromise = promisify(exec)
 


### PR DESCRIPTION
This PR adds a dynamic 'latest release badge' to the desktop and the mobile menu footer. It fetches, displays, and links to the latest release tag on page load in the format commonly found on README.md files throughout GitHub, etc.

The 2 commits are intended to be separate for provenance.

[TD-31](https://archivesspace.atlassian.net/browse/TD-31)

<img width="1512" alt="TD-31-header" src="https://github.com/user-attachments/assets/36afb399-9dbc-4cb0-8c6f-b1c66eddc5f5" />

<img width="1512" alt="TD-31-mobile" src="https://github.com/user-attachments/assets/8eccedfe-9d97-40da-a7f9-fbe5b3a34413" />

[TD-31]: https://archivesspace.atlassian.net/browse/TD-31?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ