### PR TITLE
Change release badge blue color

### DIFF
--- a/cypress/e2e/release-badge.cy.js
+++ b/cypress/e2e/release-badge.cy.js
@@ -1,7 +1,7 @@
 const releaseUrl =
   'https://github.com/archivesspace/archivesspace/releases/latest'
 const title = 'Go to the latest ArchivesSpace release'
-const badgeSrc = `https://img.shields.io/github/v/release/archivesspace/archivesspace?label=ArchivesSpace&color=007595`
+const badgeSrc = `https://img.shields.io/github/v/release/archivesspace/archivesspace?label=ArchivesSpace&color=026cb6`
 const altText = 'The latest ArchivesSpace release version'
 
 describe('Release Badge', () => {

--- a/src/components/ReleaseBadge.astro
+++ b/src/components/ReleaseBadge.astro
@@ -2,7 +2,7 @@
 const releaseUrl =
   'https://github.com/archivesspace/archivesspace/releases/latest'
 const label = 'ArchivesSpace'
-const color = '007595' // dark `--sl-color-accent` via custom.css
+const color = '026cb6' // dark blue via A_logo.svg
 const badgeSrc = `https://img.shields.io/github/v/release/archivesspace/archivesspace?label=${label}&color=${color}`
 const altText = 'The latest ArchivesSpace release version'
 const title = 'Go to the latest ArchivesSpace release'


### PR DESCRIPTION
Just changes the blue color on the recently added release badge to the dark blue from the ArchivesSpace logo.