### PR TITLE
Minor update for list linting

### DIFF
--- a/public/customizing_PUI_examples/README.md
+++ b/public/customizing_PUI_examples/README.md
@@ -15,11 +15,11 @@ The configuration file changes can be found in the config.rb file by searching f
 ## Plugins Examples
 
 Most of the plugin examples are included in the plugins/local directory:
-* Customize Field and Option Labels
-* Customize Branding Image
-* Move Branding Image from Right to Left
-* Add a Home Link to the Navigation Tool Bar
-* Change Colors
-* Change Icons
+- Customize Field and Option Labels
+- Customize Branding Image
+- Move Branding Image from Right to Left
+- Add a Home Link to the Navigation Tool Bar
+- Change Colors
+- Change Icons
 
 There is a separate help_page_pui plugin that adds a help page

--- a/src/content/docs/development/dev.md
+++ b/src/content/docs/development/dev.md
@@ -166,7 +166,7 @@ _It is not necessary and generally incorrect to manually install JRuby
 & bundler etc. for ArchivesSpace (whether with a version manager or
 otherwise)._
 
-_The self contained ArchivesSpace development environment typically does
+_The self-contained ArchivesSpace development environment typically does
 not interact with other J/Ruby environments you may have on your system
 (such as those managed by rbenv or similar)._
 


### PR DESCRIPTION
Fix for [TD-49](https://archivesspace.atlassian.net/browse/TD-49).

Commented in the above ticket: "I looked over the markdown files and could only find one place where asterisks instead of dashes. Do you know of any other way to review all the markdown files? I looked at each file individually to check, but I’m curious if there’s an automated way to do it."

[TD-49]: https://archivesspace.atlassian.net/browse/TD-49?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ