### PR TITLE
Fix the reverse range error in the branch-safe suffix logic of the new release workflow

### DIFF
--- a/.github/workflows/new-archivesspace-release.yml
+++ b/.github/workflows/new-archivesspace-release.yml
@@ -54,8 +54,8 @@ jobs:
             exit 1
           fi
 
-          # Branch-safe suffix from tag.
-          BRANCH_SUFFIX="$(echo "$TAG_NAME" | tr -cs '[:alnum:]._-'' ' '-' | sed 's/^-*//; s/-*$//')"
+          # Branch-safe suffix from tag
+          BRANCH_SUFFIX="$(printf '%s' "$TAG_NAME" | tr -cs '[:alnum:]_.-' '-' | sed 's/^-*//; s/-*$//')"
 
           echo "tag_name=$TAG_NAME" >> "$GITHUB_OUTPUT"
           echo "html_url=$HTML_URL" >> "$GITHUB_OUTPUT"
@@ -70,7 +70,7 @@ jobs:
            */
           export const LATEST_AS_RELEASE = {
             tagName: '${{ steps.release.outputs.tag_name }}',
-            htmlUrl: '${{ steps.release.outputs.html_url }}',
+            htmlUrl: '${{ steps.release.outputs.html_url }}'
           } as const
           EOF
 


### PR DESCRIPTION
When I ran [the successful dry run](https://github.com/archivesspace/tech-docs/actions/runs/23760785479) last week, I did so from this branch which fixed the error below. I neglected to open a PR with this branch at that time so doing it now.

See the [error](https://github.com/archivesspace/tech-docs/actions/runs/24131156703/job/70407850909#step:3:28) in recent (manually triggered) Action run:

```sh
shell: /usr/bin/bash --noprofile --norc -e -o pipefail {0}
tr: range-endpoints of '_- ' are in reverse collating sequence order
```