### PR TITLE
OAI tech docs update 

### DIFF
--- a/src/content/docs/architecture/oai-pmh.md
+++ b/src/content/docs/architecture/oai-pmh.md
@@ -26,9 +26,12 @@ different metadata responses available:
 - MODS -- oai_mods (archival objects and resources in MODS)
 
 The EAD response for resources and MARC response for resources and archival
-objects use the mappings from the built-in exporter for resources. The DC,
-DCMI terms, and MODS responses for resources and archival objects use mappings
-suggested by the community.
+objects use the mappings from the built-in exporter for resources. OAI EAD 
+options can be configured in AppConfig[:oai_ead_options]. The DC, DCMI terms, 
+and MODS responses for resources and archival objects use mappings suggested 
+by the community. 
+
+OAI options are set within both the [AppConfig](https://docs.archivesspace.org/customization/configuration/#oai-configuration-options) and via the Staff User Interface (System menu > Manage OAI-PMH Settings).
 
 Here are some example URLs and other information for these requests:
 
@@ -126,5 +129,5 @@ levels of the finding aid. Element inheritance is determined by institutional
 system configuration (editable in the config/config.rb file) as implemented for
 the Public User Interface.
 
-ARKs have not yet been implemented, pending more discussion of how they should
-be formulated.
+Starting in 2.7.0, there is an option to use internal or external Archival Resource Keys (ARKs) 
+in exports or OAI-PMH harvests for resources and archival objects. 

--- a/src/content/docs/architecture/oai-pmh.md
+++ b/src/content/docs/architecture/oai-pmh.md
@@ -26,12 +26,12 @@ different metadata responses available:
 - MODS -- oai_mods (archival objects and resources in MODS)
 
 The EAD response for resources and MARC response for resources and archival
-objects use the mappings from the built-in exporter for resources. OAI EAD 
-options can be configured in AppConfig[:oai_ead_options]. The DC, DCMI terms, 
-and MODS responses for resources and archival objects use mappings suggested 
-by the community. 
+objects use the mappings from the built-in exporter for resources. OAI EAD
+options can be configured in `AppConfig[:oai_ead_options]`. The DC, DCMI terms,
+and MODS responses for resources and archival objects use mappings suggested
+by the community.
 
-OAI options are set within both the [AppConfig](https://docs.archivesspace.org/customization/configuration/#oai-configuration-options) and via the Staff User Interface (System menu > Manage OAI-PMH Settings).
+OAI options are set within both the [`AppConfig`](https://docs.archivesspace.org/customization/configuration/#oai-configuration-options) and via the Staff User Interface (System menu > Manage OAI-PMH Settings).
 
 Here are some example URLs and other information for these requests:
 
@@ -129,5 +129,5 @@ levels of the finding aid. Element inheritance is determined by institutional
 system configuration (editable in the config/config.rb file) as implemented for
 the Public User Interface.
 
-Starting in 2.7.0, there is an option to use internal or external Archival Resource Keys (ARKs) 
-in exports or OAI-PMH harvests for resources and archival objects. 
+Starting in 2.7.0, there is an option to use internal or external Archival Resource Keys (ARKs)
+in exports or OAI-PMH harvests for resources and archival objects.

--- a/src/content/docs/customization/configuration.md
+++ b/src/content/docs/customization/configuration.md
@@ -216,7 +216,11 @@ Resist the urge to set this to a big number!
 
 ### OAI configuration options
 
-**NOTE: As of version 2.5.2, the following parameters (oai_repository_name, oai_record_prefix, and oai_admin_email) have been deprecated. They should be set in the Staff User Interface. To set them, select the System menu in the Staff User Interface and then select Manage OAI-PMH Settings. These three settings are at the top of the page in the General Settings section. These settings will be completely removed from the config file when version 2.6.0 is released.**
+#### ` AppConfig[:oai_ead_options]`
+
+`AppConfig[:oai_ead_options] = { :include_daos => true, :use_numbered_c_tags => true, :include_uris => false }`
+
+**NOTE: As of version 2.5.2, the following parameters (oai_repository_name, oai_record_prefix, oai_admin_email, and oai_sets) have been deprecated. They should be set in the Staff User Interface. To set them, select the System menu in the Staff User Interface and then select Manage OAI-PMH Settings. These three settings are at the top of the page in the General Settings section. These settings were removed from the config file in version 2.6.0.**
 
 #### `AppConfig[:oai_repository_name]`
 

--- a/src/content/docs/customization/configuration.md
+++ b/src/content/docs/customization/configuration.md
@@ -216,11 +216,11 @@ Resist the urge to set this to a big number!
 
 ### OAI configuration options
 
-#### ` AppConfig[:oai_ead_options]`
+#### `AppConfig[:oai_ead_options]`
 
 `AppConfig[:oai_ead_options] = { :include_daos => true, :use_numbered_c_tags => true, :include_uris => false }`
 
-**NOTE: As of version 2.5.2, the following parameters (oai_repository_name, oai_record_prefix, oai_admin_email, and oai_sets) have been deprecated. They should be set in the Staff User Interface. To set them, select the System menu in the Staff User Interface and then select Manage OAI-PMH Settings. These three settings are at the top of the page in the General Settings section. These settings were removed from the config file in version 2.6.0.**
+**NOTE: As of version 2.5.2, the following parameters (`oai_repository_name`, `oai_record_prefix`, `oai_admin_email`, and `oai_sets`) have been deprecated. They should be set in the Staff User Interface. To set them, select the System menu in the Staff User Interface and then select Manage OAI-PMH Settings. These three settings are at the top of the page in the General Settings section. These settings were removed from the config file in version 2.6.0.**
 
 #### `AppConfig[:oai_repository_name]`
 


### PR DESCRIPTION
oai-pmh.md: Added links to tech docs page on OAI appconfig options, added reference to OAI EAD options, updated reference to ARKs in OAI. Did not touch the section on OAI sets because of tickets in progress (https://archivesspace.atlassian.net/browse/ANW-2707)

configuration.md: Updated oai configuration section to include oai_ead options and note that oai_sets were removed from config along with other oai config options

