### PR TITLE
Fix PID line in systemd example to match current default PID location

### DIFF
--- a/src/content/docs/administration/unix_daemon.md
+++ b/src/content/docs/administration/unix_daemon.md
@@ -52,7 +52,7 @@ After=syslog.target network.target
 Type=forking
 ExecStart=/path/to/your/archivesspace/archivesspace.sh start
 ExecStop=/path/to/your/archivesspace/archivesspace.sh stop
-PIDFile=/path/to/your/archivesspace/archivesspace.pid
+PIDFile=/path/to/your/archivesspace/data/.archivesspace.pid
 User=archivesspace
 Group=archivesspace
 [Install]


### PR DESCRIPTION
Hi there, thanks for all your work on this application and its docs. This is a minor correction that should save folks some trouble in the future.

### Problem

While experimenting with the systemd example documented in [Running as a Unix daemon](https://docs.archivesspace.org/administration/unix_daemon/), I found that the PIDFile example didn't work as expected. It looks like the default location of that file has changed over the years.

### Resolution
I confirmed the current default location in the latest release, ArchivesSpace 4.2.0, like so:
```
$ rg "export ASPACE_PIDFILE"
archivesspace.sh
129:  export ASPACE_PIDFILE="$ASPACE_LAUNCHER_BASE/data/.archivesspace.pid"

launcher/archivesspace.sh
129:  export ASPACE_PIDFILE="$ASPACE_LAUNCHER_BASE/data/.archivesspace.pid"
```
Based on that, I modified the line in the example, and it's working well.