### PR TITLE
4.1.0 release notes

### DIFF
--- a/src/components/HomePage.astro
+++ b/src/components/HomePage.astro
@@ -33,7 +33,7 @@ import LogoMark from '@images/logo-mark.svg'
         🤖 Use the <a href="/api">API</a> to automate tasks.
       </p>
       <p>
-        📜 Read the <a href="/release-notes/v400">release notes</a>.
+        📜 Read the <a href="/release-notes/v410">release notes</a>.
       </p>
       <p>📝 Read our <a href="/blog">blog</a> for technical updates.</p>
     </div>

--- a/src/content/docs/release-notes/v4.1.0.md
+++ b/src/content/docs/release-notes/v4.1.0.md
@@ -4,7 +4,7 @@ title: v4.1.0
 
 ## ArchivesSpace v4.1.0 Release Summary
 
-This release includes enhancements to the staff and public user interfaces.  Note that this release requires a reindex.
+This release includes enhancements to the staff and public user interfaces. Note that this release requires a reindex.
 
 ## Breaking Changes
 
@@ -13,7 +13,7 @@ This release includes enhancements to the staff and public user interfaces.  Not
 
 ## Infrastructure Updates
 
-- **Breaking change**: `*_relator_sort` was removed from the Solr schema.  A reindex is required after upgrading.
+- **Breaking change**: `*_relator_sort` was removed from the Solr schema. A reindex is required after upgrading.
 - Upgrades to dependencies; cleanup of duplicative gem versions
 
 ## Public User Interface Improvements
@@ -41,4 +41,3 @@ This release includes enhancements to the staff and public user interfaces.  Not
 - `AppConfig[:search_default_scope]` was added (default `all_record_types`)
 
 ## Community Contributions
-

--- a/src/content/docs/release-notes/v4.1.0.md
+++ b/src/content/docs/release-notes/v4.1.0.md
@@ -1,0 +1,44 @@
+---
+title: v4.1.0
+---
+
+## ArchivesSpace v4.1.0 Release Summary
+
+This release includes enhancements to the staff and public user interfaces.  Note that this release requires a reindex.
+
+## Breaking Changes
+
+- **Breaking change**: [`*_relator_sort` was removed from the Solr schema](#major-infrastructure-updates)
+- **Breaking change**: [`render :inline` is replaced by `render :template` in plugins](#plugins-and-configuration)
+
+## Infrastructure Updates
+
+- **Breaking change**: `*_relator_sort` was removed from the Solr schema.  A reindex is required after upgrading.
+- Upgrades to dependencies; cleanup of duplicative gem versions
+
+## Public User Interface Improvements
+
+- Default search scope can be configured in `config.rb` (See Plugins and Configuration)
+- Improved display of mixed content in the PUI
+- Added Italian and Ukranian labels
+- PDF finding aids can be downloaded at the archival object level
+- Extents now display their portion
+
+## Staff Interface Enhancements
+
+- The Required Fields screen for Agents aligns with the Agent screen
+- Bulk Update menu option now has a help link
+- Merged agents preserve their roles in linked records
+
+## Import/Export Changes
+
+- MARCXML imports now validate subject sources
+- PUI PDFs now display Bibliography notes
+
+## Plugins and Configuration
+
+- **Breaking change**: `render :inline` is replaced by `render :template` in plugins
+- `AppConfig[:search_default_scope]` was added (default `all_record_types`)
+
+## Community Contributions
+


### PR DESCRIPTION
Release notes for version 4.1.0.  There's no ticket for this task (oops).

Following up from today's meeting, we could include a template for release notes so future ones are easy to fill out.  Is there anywhere that would be best to include the template in the repo?